### PR TITLE
Improvements from dave

### DIFF
--- a/copy.c
+++ b/copy.c
@@ -4,8 +4,9 @@
  */
 
 /* Copyright 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
+   Copyright 2008                        Dave <dloveall@users.sf.net>
    Copyright 2015                        Joao Eriberto Mota Filho <eriberto@eriberto.pro.br>
-   
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2, or (at your option)

--- a/dcfldd.c
+++ b/dcfldd.c
@@ -4,6 +4,7 @@
  */
 /* Copyright 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
    Copyright 2005                        Martin Scharrer
+   Copyright 2008                        Dave <dloveall@users.sf.net>
    Copyright 2012                        Miah Gregory <mace@debian.org>
    Copyright 2014                        Vangelis Koukis <vkoukis@gmail.com>
 

--- a/dcfldd.h
+++ b/dcfldd.h
@@ -4,6 +4,7 @@
  */
 
 /* Copyright 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
+   Copyright 2008                        Dave <dloveall@users.sf.net>
    Copyright 2017                        Joao Eriberto Mota Filho <eriberto@eriberto.pro.br>
 
    This program is free software; you can redistribute it and/or modify

--- a/dcfldd.h
+++ b/dcfldd.h
@@ -128,6 +128,7 @@ extern size_t conversion_blocksize;
 extern uintmax_t skip_records;
 extern uintmax_t seek_records;
 extern uintmax_t max_records;
+extern uintmax_t max_records_extrabytes;
 
 extern int conversions_mask;
 extern int translation_needed;

--- a/output.c
+++ b/output.c
@@ -92,11 +92,11 @@ void open_output_pipe(char *command)
 {
     FILE *stream;
 
-    stream = popen2(command, "w");
+    stream = popen(command, "w");
     if (stream == NULL)
         syscall_error(command);
 
-    outputlist_add(SINGLE_FILE, fileno(stream));
+    outputlist_add(STREAM, stream);
 }
 
 void outputlist_add(outputtype_t type, ...)
@@ -124,6 +124,11 @@ void outputlist_add(outputtype_t type, ...)
     switch (type) {
     case SINGLE_FILE:
         ptr->data.fd = va_arg(ap, int);
+        break;
+    case STREAM:
+        ptr->type = SINGLE_FILE;
+        ptr->stream = va_arg(ap, FILE *);
+        ptr->data.fd = fileno(ptr->stream);
         break;
     case SPLIT_FILE:
         split = malloc(sizeof *split);

--- a/output.c
+++ b/output.c
@@ -3,8 +3,9 @@
  * By Nicholas Harbour
  */
 
-/* Copyright (C) 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
-   
+/* Copyright 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
+   Copyright 2008                        Dave <dloveall@users.sf.net>
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2, or (at your option)

--- a/output.h
+++ b/output.h
@@ -32,13 +32,15 @@ typedef enum
 {
     NONE,
     SINGLE_FILE,
-    SPLIT_FILE
+    SPLIT_FILE,
+    STREAM
 } outputtype_t;
 
 typedef struct outputlist_s
 {
     struct outputlist_s *next;
     outputtype_t type;
+    FILE *stream;
     union {
         int fd;
         split_t *split;

--- a/output.h
+++ b/output.h
@@ -3,8 +3,9 @@
  * By Nicholas Harbour
  */
 
-/* Copyright (C) 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
-   
+/* Copyright 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
+   Copyright 2008                        Dave <dloveall@users.sf.net>
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2, or (at your option)

--- a/sizeprobe.h
+++ b/sizeprobe.h
@@ -27,7 +27,7 @@
 #include "dcfldd.h"
 #include <sys/types.h>
 
-enum {PROBE_NONE = 0, PROBE_INPUT, PROBE_OUTPUT};
+enum {PROBE_NONE = 0, PROBE_INPUT, PROBE_OUTPUT, PROBE_INPUT_PROVIDED};
 
 extern int probe;
 extern off_t probed_size;

--- a/sizeprobe.h
+++ b/sizeprobe.h
@@ -3,8 +3,9 @@
  * By Nicholas Harbour
  */
 
-/* Copyright (C) 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
-   
+/* Copyright 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
+   Copyright 2008                        Dave <dloveall@users.sf.net>
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2, or (at your option)

--- a/split.c
+++ b/split.c
@@ -57,6 +57,20 @@ static char *getext(char *fmt, int num)
     
     assert(fmtlen > 0);
 
+    if (strcmp(fmt, "MAC") == 0) {
+      if (num == 0) {
+	asprintf(&retval, "dmg");
+      } else {
+	asprintf(&retval, "%03d.dmgpart", num+1);
+      }
+      return retval;
+    }
+
+    if (strcmp(fmt, "WIN") == 0) {
+      asprintf(&retval, "%03d", num+1);
+      return retval;
+    }
+
     retval = malloc(fmtlen);
 
     /* Fill the retval in reverse while constantly dividing num apropriately */
@@ -115,6 +129,7 @@ static void open_split(split_t *split)
     if (fd < 0)
         syscall_error(fname);
 
+    close(split->currfd);
     split->currfd = fd;
     split->curr_bytes = 0;
     

--- a/split.c
+++ b/split.c
@@ -3,6 +3,7 @@
  * By Nicholas Harbour
  */
 /* Copyright 85, 90, 91, 1995-2001, 2005 Free Software Foundation, Inc.
+   Copyright 2008                        Dave <dloveall@users.sf.net>
    Copyright 2012                        Miah Gregory <mace@debian.org>
    Copyright 2015                        Joao Eriberto Mota Filho <eriberto@eriberto.pro.br>
 


### PR DESCRIPTION
    Several changes and improvements
    
    From SF.net[1]. Changes from Dave.
    
    [1] https://sourceforge.net/p/dcfldd/patches/3/
    
    Additions:
    
    * Allows for partial write of block during conv=sync if at the end of input.
    * Allows limit=<# of bytes> to limit the count of input, rather than
      count=<# of blocks>.
    * Closes all popened processes. (Uses internal popen call, rather than original
      popen2.)
    * Allows sizeprobe=<# of bytes> to manually specify.
    * Allows for splitformat=MAC to use output file naming of foo.dmg,
      foo.002.dmgpart, ..., foo.999.dmgpart, foo.1000.dmgpart, ....
    * Allows for splitformat=WIN to use output file naming of foo.001, foo.002,
      ..., foo.999, foo.1000, ....
    * Fixes too many opened files bug.
    
    The following change in dcfldd.c was rejected because the source code is
     updated:
    
    @@ -760,6 +794,8 @@
                 sizeprobe(STDIN_FILENO);
         else if (probe == PROBE_OUTPUT)
             sizeprobe(STDOUT_FILENO);
    +    if (probe == PROBE_INPUT_PROVIDED)
    +      probe = PROBE_INPUT;
         start_time = time(NULL);
    
         if (do_verify)