### PR TITLE
Add diffwr option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Upcoming version
+
+    [ Tibor Szolnoki ]
+
+ * Added support for write only to output if destination block content is differs ('diffwr' option).
+
 2022-10-17  Joao Eriberto Mota Filho <eriberto@eriberto.pro.br>
 Version 1.8
 

--- a/man/dcfldd.1
+++ b/man/dcfldd.1
@@ -207,6 +207,11 @@ verifylog:=COMMAND
 Exec and write verify results to process COMMAND.
 .TP
 .B
+diffwr=[on|off]
+Write only to output if destination block content is differs. This operation 
+applies to any of=FILE that follows (diffwr= must be put before of=)
+.TP
+.B
 \fB--help\fP
 Display a help page and exit.
 .TP

--- a/man/dcfldd.txt
+++ b/man/dcfldd.txt
@@ -97,6 +97,8 @@ OPTIONS
   vf=FILE                  Verify that FILE matches the specified input.
   verifylog=FILE           Send verify results to FILE instead of stderr.
   verifylog:=COMMAND       Exec and write verify results to process COMMAND.
+  diffwr=[on|off]          Write only to output if destination block content is differs. This operation 
+                           applies to any of=FILE that follows (diffwr= must be put before of=)
   --help                   Display a help page and exit.
   --version                Output version information and exit.
 

--- a/src/dcfldd.c
+++ b/src/dcfldd.c
@@ -133,6 +133,7 @@ int do_status = 1;
 int do_hash = 0;
 int do_verify = 0;
 int do_split = 0;
+int do_diffwr = 0;
 
 hashconv_t hashconv = DEFAULT_HASHCONV;
 
@@ -202,6 +203,7 @@ Enhanced version of dd for forensics and security.\n\
   vf=FILE                  verify that FILE matches the specified input\n\
   verifylog=FILE           send verify results to FILE instead of stderr\n\
   verifylog:=COMMAND       exec and write verify results to process COMMAND\n\
+  diffwr=[on|off]          write only to output if destination block content differs\n\
 \n\
   --help              display this help and exit\n\
   --version           output version information and exit\n\
@@ -579,6 +581,11 @@ static void scanargs(int argc, char **argv)
 	      if (invalid)
 		probe = PROBE_NONE;
 	    }
+        } else if (STREQ(name, "diffwr")) {
+                if (STREQ(val, "off"))
+                    do_diffwr = 0;
+                else if (STREQ(val, "on"))
+                    do_diffwr = 1;
         } else {
             int invalid = 0;
             uintmax_t n = parse_integer(val, &invalid);

--- a/src/dcfldd.h
+++ b/src/dcfldd.h
@@ -144,6 +144,7 @@ extern uintmax_t r_truncate;
 extern int do_hash;
 extern int do_verify;
 extern int do_status;
+extern int do_diffwr;
 
 extern int char_is_saved;
 extern unsigned char saved_char;

--- a/src/full-write.h
+++ b/src/full-write.h
@@ -24,6 +24,6 @@
 #ifndef FULL_WRITE_H
 #define FULL_WRITE_H
 
-int full_write(int, const char *, size_t);
+int full_write(int, const char *, size_t, int diffwr);
 
 #endif /* FULL_WRITE_H */

--- a/src/output.h
+++ b/src/output.h
@@ -46,6 +46,7 @@ typedef struct outputlist_s
         int fd;
         split_t *split;
     } data;
+    int diffwr;
 } outputlist_t;
 
 extern outputlist_t *outputlist;

--- a/src/split.c
+++ b/src/split.c
@@ -140,7 +140,7 @@ static void open_split(split_t *split)
     free(fname);
 }
 
-int split_write(split_t *split, const char *buf, size_t len)
+int split_write(split_t *split, const char *buf, size_t len, int diffwr)
 {
     off_t left = split->max_bytes - split->curr_bytes;
     int nwritten = 0;
@@ -151,14 +151,14 @@ int split_write(split_t *split, const char *buf, size_t len)
     }
 
     if (len <= left) {
-        nwritten = full_write(split->currfd, buf, len);
+        nwritten = full_write(split->currfd, buf, len, diffwr);
         split->total_bytes += nwritten;
         split->curr_bytes += nwritten;
     } else {
-        nwritten = full_write(split->currfd, buf, left);
+        nwritten = full_write(split->currfd, buf, left, diffwr);
         split->total_bytes += nwritten;
         split->curr_bytes += nwritten;
-        nwritten += split_write(split, &buf[nwritten], len - nwritten);
+        nwritten += split_write(split, &buf[nwritten], len - nwritten, diffwr);
     }
 
     return nwritten;

--- a/src/split.h
+++ b/src/split.h
@@ -36,6 +36,6 @@ typedef struct
     char *format;
 } split_t;
 
-extern int split_write(split_t *, const char *, size_t);
+extern int split_write(split_t *, const char *, size_t, int diffwr);
 
 #endif /* SPLIT_H */


### PR DESCRIPTION
'diffwr': write only to output if destination block content is differs [on/off]
Default: off (working as original dcfldd)

Good feature, if the destination device is an SSD/flash/thumb drive device, and only some parts of source and destination(s) are different. For example: restore the SSD from an image file. The total speed much more faster, because of read instead full device write. And the smaller quantity of write not wearing SDD/flash device.

Working not only on block device, but working on plain image files as destination.

Tested many times with image files as source and real flash devices as destination, with destination re-checking. I used this feature practically on my forensic job, when I restore an SSD system disk cyclic. After every boot, I needed to restore the SSD disk from original image every time, again and again. Beacuse only small parts of system disk was modified at every boot, the "different write" was much more faster and "gentle" as full disk write. Without this feature, the full disk restore was half hour, with diffwr was only minutes. But the result on the SSD was same bit-by-bit.

diffwr feature only affects full_write function only. Not affects any other dcfldd functions any way. This feature is error proof. If destination read is not possible any way before write, this fall backs to default write operation. This provide, the result on destination will be always complete. In the full_write function, debug is possible (#if 1) to see, what blocks are written in real.

Fixed, and improved a little bit. Now, can change this settings before every 'of' options, like 'split" option. For example:
dcfldd in=foo of=out1 diffwr=on of=out2 diffwr=off of=out4 of=out5
In the example, different write will be use only for "out2".

I hope, the forensics community use this feature with happy.