### PR TITLE
Add ./configure switch to enable bash-completion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,11 @@
 
 AUTOMAKE_OPTIONS = foreign no-dependencies
 
+if ENABLE_BASH_COMPLETION
+bashcompletiondir = $(BASH_COMPLETION_DIR)
+dist_bashcompletion_DATA = doc/dcfldd-bash_completion
+endif
+
 SUBDIRS = src
 
 man_MANS = man/dcfldd.1

--- a/configure.ac
+++ b/configure.ac
@@ -48,11 +48,11 @@ AC_ARG_ENABLE([runtime-endian-check],
     AC_HELP_STRING([--disable-runtime-endian-check], [disable runtime checks for endianness])
 )
 
-AC_ARG_WITH([bash-completion-dir],
-    AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
+AC_ARG_WITH([bash-completion],
+    AS_HELP_STRING([--with-bash-completion[=PATH]],
                    [Install the bash auto-completion script in this directory. @<:@default=no@:>@]),
     [],
-    [with_bash_completion_dir=no]
+    [with_bash_completion=no]
 )
 
 AS_IF([test "x$enable_runtime_endian_check" != "xno"], [
@@ -60,18 +60,18 @@ AS_IF([test "x$enable_runtime_endian_check" != "xno"], [
     AC_DEFINE([RUNTIME_ENDIAN], 1, [Define whether to check for endianness during runtime])
 ])
 
-if test "x$with_bash_completion_dir" == "xyes"; then
+if test "x$with_bash_completion" == "xyes"; then
     PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
         [BASH_COMPLETION_DIR="`$PKG_CONFIG --variable=completionsdir bash-completion`"],
         [BASH_COMPLETION_DIR="$datadir/bash-completion/completions"])
 else
-    BASH_COMPLETION_DIR="$with_bash_completion_dir"
+    BASH_COMPLETION_DIR="$with_bash_completion"
 fi
 
 AC_CHECK_DECLS([strtol, strtoul, strtoumax, strndup])
 
 AC_SUBST([BASH_COMPLETION_DIR])
-AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "xno"])
+AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion" != "xno"])
 
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,8 @@ AM_INIT_AUTOMAKE
 AC_CONFIG_HEADERS([config.h])
 AC_CANONICAL_HOST
 
+PKG_PROG_PKG_CONFIG
+
 AC_PROG_CC
 AC_PROG_CPP
 AC_PROG_GCC_TRADITIONAL
@@ -46,12 +48,30 @@ AC_ARG_ENABLE([runtime-endian-check],
     AC_HELP_STRING([--disable-runtime-endian-check], [disable runtime checks for endianness])
 )
 
+AC_ARG_WITH([bash-completion-dir],
+    AS_HELP_STRING([--with-bash-completion-dir[=PATH]],
+                   [Install the bash auto-completion script in this directory. @<:@default=no@:>@]),
+    [],
+    [with_bash_completion_dir=no]
+)
+
 AS_IF([test "x$enable_runtime_endian_check" != "xno"], [
     dnl Do the stuff needed for enabling the feature
     AC_DEFINE([RUNTIME_ENDIAN], 1, [Define whether to check for endianness during runtime])
 ])
 
+if test "x$with_bash_completion_dir" == "xyes"; then
+    PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
+        [BASH_COMPLETION_DIR="`$PKG_CONFIG --variable=completionsdir bash-completion`"],
+        [BASH_COMPLETION_DIR="$datadir/bash-completion/completions"])
+else
+    BASH_COMPLETION_DIR="$with_bash_completion_dir"
+fi
+
 AC_CHECK_DECLS([strtol, strtoul, strtoumax, strndup])
+
+AC_SUBST([BASH_COMPLETION_DIR])
+AM_CONDITIONAL([ENABLE_BASH_COMPLETION],[test "x$with_bash_completion_dir" != "xno"])
 
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT


### PR DESCRIPTION
This PR was opened to keep track of the implementation of the `./configure` switch that will allow for installation of dcfldd bash-completion script.