### PR TITLE
sha2: fix aliasing violation

### DIFF
--- a/src/sha2.c
+++ b/src/sha2.c
@@ -604,7 +604,7 @@ void SHA256_Final(SHA256_CTX* context, sha2_byte digest[]) {
 			*context->buffer = 0x80;
 		}
 		/* Set the bit count: */
-		*(sha2_word64*)&context->buffer[SHA256_SHORT_BLOCK_LENGTH] = context->bitcount;
+		memcpy(&context->buffer[SHA256_SHORT_BLOCK_LENGTH], &context->bitcount, sizeof(context->bitcount));
 
 		/* Final transform: */
 		SHA256_Transform(context, (sha2_word32*)context->buffer);
@@ -921,8 +921,8 @@ void SHA512_Last(SHA512_CTX* context) {
 		*context->buffer = 0x80;
 	}
 	/* Store the length of input data (in bits): */
-	*(sha2_word64*)&context->buffer[SHA512_SHORT_BLOCK_LENGTH] = context->bitcount[1];
-	*(sha2_word64*)&context->buffer[SHA512_SHORT_BLOCK_LENGTH+8] = context->bitcount[0];
+	memcpy(&context->buffer[SHA512_SHORT_BLOCK_LENGTH], &context->bitcount[1], sizeof(context->bitcount[1]));
+	memcpy(&context->buffer[SHA512_SHORT_BLOCK_LENGTH+8], &context->bitcount[0], sizeof(context->bitcount[0]));
 
 	/* Final transform: */
 	SHA512_Transform(context, (sha2_word64*)context->buffer);


### PR DESCRIPTION
sha2: fix aliasing violation

`&context->buffer` is `uint8_t*`, but we try to access it as `sha2_word64*`, which
is an aliasing violation (undefined behaviour).

Use memcpy instead to avoid being miscompiled by e.g. >= GCC 12. This is
just as fast with any modern compiler.

Bug: https://gcc.gnu.org/PR114698
Bug: https://github.com/NetBSD/pkgsrc/issues/122
Bug: https://github.com/archiecobbs/libnbcompat/issues/4
Bug: https://bugs.launchpad.net/ubuntu-power-systems/+bug/2033405
Signed-off-by: Sam James <sam@gentoo.org>