### PR TITLE
sha2: fix another instance of -Wsizeof-pointer-memaccess

### DIFF
--- a/src/sha2.c
+++ b/src/sha2.c
@@ -1029,7 +1029,7 @@ void SHA384_Final(SHA384_CTX* context, sha2_byte digest[]) {
 	}
 
 	/* Zero out state data */
-	MEMSET_BZERO(context, sizeof(context));
+	MEMSET_BZERO(context, sizeof(*context));
 }
 
 char *SHA384_End(SHA384_CTX* context, char buffer[]) {


### PR DESCRIPTION
When reviewing https://github.com/resurrecting-open-source-projects/dcfldd/pull/24, @davidpolverari pointed out a mistake I made in one revision - oops.

While fixing that, I noticed:
```
sha2.c: In function ‘SHA384_End’:
sha2.c:1052:45: error: argument to ‘sizeof’ in ‘memset’ call is the same expression as the destination; did you mean to dereference it? [-Werror=sizeof-pointer-memaccess]
 1052 |                 MEMSET_BZERO(context, sizeof(context));
      |                                             ^
sha2.c:176:49: note: in definition of macro ‘MEMSET_BZERO’
  176 | #define MEMSET_BZERO(p,l)       memset((p), 0, (l))
      |                                                 ^
cc1: some warnings being treated as errors
```

Let's fix that too, while we're at it.