### PR TITLE
`src/output.c`: Initialize `outputtype_t.stream` memory properly a.k.a. fix segfault caught by AddressSanitizer

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -126,6 +126,7 @@ void outputlist_add(outputtype_t type, ...)
 
     ptr->next = NULL;
     ptr->type = type;
+    ptr->stream = NULL;
     ptr->diffwr = do_diffwr;
 
     switch (type) {


### PR DESCRIPTION
.. so that cleanup has no chance of reading uninitilized memory.

Symptom was:
```console
# src/dcfldd if=.github/workflows/test.txt of=/dev/null

0+1 records in
0+1 records out
AddressSanitizer:DEADLYSIGNAL
=================================================================
==32016==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x7f5c82649b74 bp 0x7fff492a9b01 sp 0x7fff492a9a90 T0)
==32016==The signal is caused by a READ memory access.
==32016==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
    #0 0x7f5c82649b74 in fclose (/lib64/libc.so.6+0x72b74)
    #1 0x561f3a6b1898 in pclose /var/tmp/portage/sys-libs/compiler-rt-sanitizers-18.1.4/work/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:9690:13
    #2 0x561f3a719fb4 in cleanup [..]/src/dcfldd.c:262:2
    #3 0x561f3a71a087 in quit [..]/src/dcfldd.c:268:5
    #4 0x561f3a71bdbe in main [..]/src/dcfldd.c:760:5
    #5 0x7f5c825fce49  (/lib64/libc.so.6+0x25e49)
    #6 0x7f5c825fcf04 in __libc_start_main (/lib64/libc.so.6+0x25f04)
    #7 0x561f3a6414c0 in _start ([..]/src/dcfldd+0x584c0)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/lib64/libc.so.6+0x72b74) in fclose
==32016==ABORTING
```