### PR TITLE
`full-check.yml`: Bump to `ubuntu-24.04` and GCC 14 to fix CI

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -8,9 +8,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cc: gcc-13
+          - cc: gcc-14
             clang_major_version: null
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
           - cc: clang-18
             clang_major_version: 18
             runs-on: ubuntu-22.04


### PR DESCRIPTION
.. because `ubuntu-22.04` suddenly dropped GCC 13.

Related:
- https://github.com/actions/runner-images/issues/9866
- https://github.com/actions/runner-images/issues/9679

CC @davidpolverari 