### PR TITLE
Fix support for musl libc 

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -53,10 +53,19 @@ jobs:
            make distclean
     - name: second_build
       run: |
+           configure_args=(
+             CC=${{ matrix.cc }}
+           )
+
+           if [[ "${{ matrix.cc }}" != musl-gcc ]]; then
+             configure_args+=(
+               CFLAGS='-g -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer'
+               LDFLAGS='-g -fsanitize=address,undefined'
+             )
+           fi
+
            ./autogen.sh
-           ./configure CC=${{ matrix.cc }} \
-             CFLAGS='-g -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer' \
-             LDFLAGS='-g -fsanitize=address,undefined' \
+           ./configure "${configure_args[@]}" \
              || { cat config.log ; false ; }
            make
            sudo make install

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -14,6 +14,9 @@ jobs:
           - cc: clang-18
             clang_major_version: 18
             runs-on: ubuntu-22.04
+          - cc: musl-gcc
+            clang_major_version: null
+            runs-on: ubuntu-24.04
 
     runs-on: ${{ matrix.runs-on }}
 
@@ -33,6 +36,12 @@ jobs:
            sudo apt-get install --yes --no-install-recommends -V \
              clang-${{ matrix.clang_major_version }} \
              libclang-rt-${{ matrix.clang_major_version }}-dev
+    - name: musl_tools_install
+      if: "${{ contains(matrix.cc, 'musl') }}"
+      run: |-
+           sudo apt-get update
+           sudo apt-get install --yes --no-install-recommends -V \
+             musl-tools
     - name: first_build
       run: |
            ./autogen.sh

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -36,7 +36,8 @@ jobs:
     - name: first_build
       run: |
            ./autogen.sh
-           ./configure CC=${{ matrix.cc }} CFLAGS='-std=c99 -Wall -Wextra -pedantic'
+           ./configure CC=${{ matrix.cc }} CFLAGS='-std=c99 -Wall -Wextra -pedantic' \
+             || { cat config.log ; false ; }
            make
            sudo make install
            sudo make uninstall
@@ -46,7 +47,8 @@ jobs:
            ./autogen.sh
            ./configure CC=${{ matrix.cc }} \
              CFLAGS='-g -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer' \
-             LDFLAGS='-g -fsanitize=address,undefined'
+             LDFLAGS='-g -fsanitize=address,undefined' \
+             || { cat config.log ; false ; }
            make
            sudo make install
     - name: run_program

--- a/src/sha2.h
+++ b/src/sha2.h
@@ -35,6 +35,10 @@
 #ifndef __SHA2_H__
 #define __SHA2_H__
 
+# if HAVE_CONFIG_H
+#  include <config.h>
+# endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,7 +57,7 @@ extern "C" {
  * Define the followingsha2_* types to types of the correct length on
  * the native archtecture.   Most BSD systems and Linux define u_intXX_t
  * types.  Machines with very recent ANSI C headers, can use the
- * uintXX_t definintions from inttypes.h by defining SHA2_USE_INTTYPES_H
+ * uintXX_t definintions from inttypes.h by defining HAVE_INTTYPES_H
  * during compile or in the sha.h header file.
  *
  * Machines that support neither u_intXX_t nor inttypes.h's uintXX_t
@@ -63,7 +67,7 @@ extern "C" {
  * Thank you, Jun-ichiro itojun Hagino, for suggesting using u_intXX_t
  * types and pointing out recent ANSI C support for uintXX_t in inttypes.h.
  */
-#ifdef SHA2_USE_INTTYPES_H
+#ifdef HAVE_INTTYPES_H
 
 #include <inttypes.h>
 
@@ -71,13 +75,13 @@ typedef uint8_t  sha2_byte;	/* Exactly 1 byte */
 typedef uint32_t sha2_word32;	/* Exactly 4 bytes */
 typedef uint64_t sha2_word64;	/* Exactly 8 bytes */
 
-#else /* SHA2_USE_INTTYPES_H */
+#else /* HAVE_INTTYPES_H */
 
 typedef u_int8_t  sha2_byte;	/* Exactly 1 byte */
 typedef u_int32_t sha2_word32;	/* Exactly 4 bytes */
 typedef u_int64_t sha2_word64;	/* Exactly 8 bytes */
 
-#endif /* SHA2_USE_INTTYPES_H */
+#endif /* HAVE_INTTYPES_H */
 
 /*** SHA-256/384/512 Various Length Definitions ***********************/
 #define SHA256_BLOCK_LENGTH		64
@@ -111,13 +115,13 @@ typedef unsigned long long u_int64_t;	/* 8-bytes (64-bits) */
  *
  * If you choose to use <inttypes.h> then please define:
  *
- *   #define SHA2_USE_INTTYPES_H
+ *   #define HAVE_INTTYPES_H
  *
  * Or on the command line during compile:
  *
- *   cc -DSHA2_USE_INTTYPES_H ...
+ *   cc -DHAVE_INTTYPES_H ...
  */
-#ifdef SHA2_USE_INTTYPES_H
+#ifdef HAVE_INTTYPES_H
 
 typedef struct _SHA256_CTX {
 	uint32_t	state[8];
@@ -130,7 +134,7 @@ typedef struct _SHA512_CTX {
 	uint8_t	buffer[SHA512_BLOCK_LENGTH];
 } SHA512_CTX;
 
-#else /* SHA2_USE_INTTYPES_H */
+#else /* HAVE_INTTYPES_H */
 
 typedef struct _SHA256_CTX {
 	u_int32_t	state[8];
@@ -143,14 +147,14 @@ typedef struct _SHA512_CTX {
 	u_int8_t	buffer[SHA512_BLOCK_LENGTH];
 } SHA512_CTX;
 
-#endif /* SHA2_USE_INTTYPES_H */
+#endif /* HAVE_INTTYPES_H */
 
 typedef SHA512_CTX SHA384_CTX;
 
 
 /*** SHA-256/384/512 Function Prototypes ******************************/
 #ifndef NOPROTO
-#ifdef SHA2_USE_INTTYPES_H
+#ifdef HAVE_INTTYPES_H
 
 void SHA256_Init(SHA256_CTX *);
 void SHA256_Update(SHA256_CTX*, const uint8_t*, size_t);
@@ -170,7 +174,7 @@ void SHA512_Final(SHA512_CTX*, uint8_t[SHA512_DIGEST_LENGTH]);
 char* SHA512_End(SHA512_CTX*, char[SHA512_DIGEST_STRING_LENGTH]);
 char* SHA512_Data(const uint8_t*, size_t, char[SHA512_DIGEST_STRING_LENGTH]);
 
-#else /* SHA2_USE_INTTYPES_H */
+#else /* HAVE_INTTYPES_H */
 
 void SHA256_Init(SHA256_CTX *);
 void SHA256_Update(SHA256_CTX*, const u_int8_t*, size_t);
@@ -190,7 +194,7 @@ void SHA512_Final(SHA512_CTX*, u_int8_t[SHA512_DIGEST_LENGTH]);
 char* SHA512_End(SHA512_CTX*, char[SHA512_DIGEST_STRING_LENGTH]);
 char* SHA512_Data(const u_int8_t*, size_t, char[SHA512_DIGEST_STRING_LENGTH]);
 
-#endif /* SHA2_USE_INTTYPES_H */
+#endif /* HAVE_INTTYPES_H */
 
 #else /* NOPROTO */
 

--- a/src/util.c
+++ b/src/util.c
@@ -120,7 +120,6 @@ void skip2(int fdesc, char *file, uintmax_t records, size_t blocksize,
 
 #ifdef __linux__
 
-# include <error.h>
 # include <sys/mtio.h>
 
 # define MT_SAME_POSITION(P, Q) \
@@ -144,9 +143,12 @@ static off_t skip_via_lseek(char const *filename, int fdesc, off_t offset,
         && ioctl (fdesc, MTIOCGET, &s2) == 0
         && MT_SAME_POSITION (s1, s2))
     {
-        error (0, 0, _("warning: working around lseek kernel bug for file (%s)\n\
+        fflush(stdout);
+        fprintf(stderr, "dcfldd: ");
+        fprintf(stderr, _("warning: working around lseek kernel bug for file (%s)\n\
   of mt_type=0x%0lx -- see <sys/mtio.h> for the list of types"),
                filename, s2.mt_type);
+        fprintf(stderr, "\n");
         errno = 0;
         new_position = -1;
     }

--- a/src/xstrtol.c
+++ b/src/xstrtol.c
@@ -252,7 +252,6 @@ __xstrtol (const char *s, char **ptr, int strtol_base,
 #ifdef TESTING_XSTRTO
 
 # include <stdio.h>
-# include "error.h"
 
 char *program_name;
 

--- a/src/xstrtol.h
+++ b/src/xstrtol.h
@@ -38,18 +38,24 @@ _DECLARE_XSTRTOL (xstrtoumax, uintmax_t)
 	  abort ();							\
 									\
 	case LONGINT_INVALID:						\
-	  error ((Exit_code), 0, "invalid %s `%s'",			\
+	  fflush (stdout);						\
+	  fprintf (stderr, "dcfldd: invalid %s `%s'\n",			\
 		 (Argument_type_string), (Str));			\
+	  if ((Exit_code) != 0) exit((Exit_code));			\
 	  break;							\
 									\
 	case LONGINT_INVALID_SUFFIX_CHAR:				\
-	  error ((Exit_code), 0, "invalid character following %s `%s'",	\
+	  fflush (stdout);						\
+	  fprintf (stderr, "dcfldd: invalid character following %s `%s'\n", \
 		 (Argument_type_string), (Str));			\
+	  if ((Exit_code) != 0) exit((Exit_code));			\
 	  break;							\
 									\
 	case LONGINT_OVERFLOW:						\
-	  error ((Exit_code), 0, "%s `%s' too large",			\
+	  fflush (stdout);						\
+	  fprintf (stderr, "dcfldd: %s `%s' too large\n",		\
 		 (Argument_type_string), (Str));			\
+	  if ((Exit_code) != 0) exit((Exit_code));			\
 	  break;							\
 	}								\
     }									\


### PR DESCRIPTION
Hi!

First: This is just a draft. I can turn it into something more mergable once the requirements for a mergable version are clear — please let me know.

---

It [was brought to my attention](https://bugs.gentoo.org/713646) that dcfldd makes use of header `error.h` and function `error(3)` that both glibc has and musl doesn't. My patches here replace these uses and hence fix support for musl. They are based on (1) an idea from https://gitlab.alpinelinux.org/hason/aports/-/blob/v3.3.0/testing/dcfldd/dcfldd-error.patch and (2) reading the `error(3)` man page.

From the `error(3)` man page I would like to quote these highlights:
- "It flushes stdout [..]"
- "[..] and then outputs to stderr the program name, a colon and a space [..]"
- "The output is terminated by a newline character."
- "If status has a nonzero value, then error() calls exit(3) to terminate the program[.]"

More context can be found below:

```
error(3)               Library Functions Manual              error(3)

NAME
       error, error_at_line, error_message_count, error_one_per_line,
       error_print_progname - glibc error reporting functions

LIBRARY
       Standard C library (libc, -lc)

SYNOPSIS
       #include <error.h>

       void error(int status, int errnum, const char *format, ...);
[..]

DESCRIPTION
       error()  is  a  general  error-reporting function.  It flushes
       stdout, and then outputs to stderr the program name,  a  colon
       and a space, the message specified by the printf(3)-style for‐
       mat  string  format, and, if errnum is nonzero, a second colon
       and a space followed by the string given by  strerror(errnum).
       Any  arguments required for format should follow format in the
       argument list.  The output is terminated by a newline  charac‐
       ter.

       The program name printed by error() is the value of the global
       variable  program_invocation_name(3).  program_invocation_name
       initially has the same value as main()’s argv[0].   The  value
       of  this  variable can be modified to change the output of er‐
       ror().

       If status has a nonzero value, then error() calls  exit(3)  to
       terminate  the  program using the given value as the exit sta‐
       tus; otherwise it returns after printing the error message.

       [..]
```

What do you think?