### PR TITLE
Replace glibc's error() with own implementation

### DIFF
--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -53,10 +53,19 @@ jobs:
            make distclean
     - name: second_build
       run: |
+           configure_args=(
+             CC=${{ matrix.cc }}
+           )
+
+           if [[ "${{ matrix.cc }}" != musl-gcc ]]; then
+             configure_args+=(
+               CFLAGS='-g -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer'
+               LDFLAGS='-g -fsanitize=address,undefined'
+             )
+           fi
+
            ./autogen.sh
-           ./configure CC=${{ matrix.cc }} \
-             CFLAGS='-g -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer' \
-             LDFLAGS='-g -fsanitize=address,undefined' \
+           ./configure "${configure_args[@]}" \
              || { cat config.log ; false ; }
            make
            sudo make install

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -36,7 +36,8 @@ jobs:
     - name: first_build
       run: |
            ./autogen.sh
-           ./configure CC=${{ matrix.cc }} CFLAGS='-std=c99 -Wall -Wextra -pedantic'
+           ./configure CC=${{ matrix.cc }} CFLAGS='-std=c99 -Wall -Wextra -pedantic' \
+             || { cat config.log ; false ; }
            make
            sudo make install
            sudo make uninstall
@@ -46,7 +47,8 @@ jobs:
            ./autogen.sh
            ./configure CC=${{ matrix.cc }} \
              CFLAGS='-g -fsanitize=address,undefined -fno-sanitize-recover=all -fno-omit-frame-pointer' \
-             LDFLAGS='-g -fsanitize=address,undefined'
+             LDFLAGS='-g -fsanitize=address,undefined' \
+             || { cat config.log ; false ; }
            make
            sudo make install
     - name: run_program

--- a/.github/workflows/full-check.yml
+++ b/.github/workflows/full-check.yml
@@ -14,6 +14,9 @@ jobs:
           - cc: clang-19
             clang_major_version: 19
             runs-on: ubuntu-22.04
+          - cc: musl-gcc
+            clang_major_version: null
+            runs-on: ubuntu-24.04
 
     runs-on: ${{ matrix.runs-on }}
 
@@ -33,6 +36,12 @@ jobs:
            sudo apt-get install --yes --no-install-recommends -V \
              clang-${{ matrix.clang_major_version }} \
              libclang-rt-${{ matrix.clang_major_version }}-dev
+    - name: musl_tools_install
+      if: "${{ contains(matrix.cc, 'musl') }}"
+      run: |-
+           sudo apt-get update
+           sudo apt-get install --yes --no-install-recommends -V \
+             musl-tools
     - name: first_build
       run: |
            ./autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ AC_INIT([dcfldd],[1.9.1],[https://github.com/resurrecting-open-source-projects/d
 AC_CONFIG_SRCDIR(src/dcfldd.c)
 AM_INIT_AUTOMAKE
 
+AC_HEADER_ASSERT
 AC_CONFIG_HEADERS([config.h])
 AC_CANONICAL_HOST
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,4 +49,5 @@ dcfldd_SOURCES = dcfldd.c \
                  full-write.h \
                  output.c output.h \
                  split.c split.h \
-                 hashformat.c hashformat.h
+                 hashformat.c hashformat.h \
+                 dcfldd_error.c dcfldd_error.h

--- a/src/dcfldd_error.c
+++ b/src/dcfldd_error.c
@@ -26,7 +26,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "dcfldd.h"	// to use program_name
+#ifdef _LIBC	// GNU C library uses program_invocation_name for error(3).
+# define program_name program_invocation_name
+#endif
+
+// calling program must define program_name and set it to argv[0]
+extern char *program_name;
 
 /*
  * dcfldd_error(): a replacement for glibc's error() for usage within dcfldd

--- a/src/dcfldd_error.c
+++ b/src/dcfldd_error.c
@@ -26,19 +26,17 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef _LIBC	// GNU C library uses program_invocation_name for error(3).
-# define program_name program_invocation_name
-#endif
-
-// calling program must define program_name and set it to argv[0]
+// dcfldd defines program_name and sets it to argv[0]
 extern char *program_name;
 
 /*
  * dcfldd_error(): a replacement for glibc's error() for usage within dcfldd
  *
  * WARNING: this function is not intended as a full drop-in replacement for
- * error(). One of the most glaring differences from error() is the usage of
- * dcfldd's program_name instead of program_invocation_name.
+ * error(). One example difference is that glibc's error function reads the
+ * program name from a global variable "program_invocation_name" (see "man 3
+ * program_invocation_name") whereas the implementation here is using dcfldd's
+ * own global variable "program_name", instead.
  */
 
 void

--- a/src/dcfldd_error.c
+++ b/src/dcfldd_error.c
@@ -1,0 +1,61 @@
+/*
+ * dcfldd_error.c -- replacement for non-portable GNU libc's error()
+ * Copyright (C) 2024 David da Silva Polverari
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dcfldd.h"	// to use program_name
+
+/*
+ * dcfldd_error(): a replacement for glibc's error() for usage within dcfldd
+ *
+ * WARNING: this function is not intended as a full drop-in replacement for
+ * error(). One of the most glaring differences from error() is the usage of
+ * dcfldd's program_name instead of program_invocation_name.
+ */
+
+void
+dcfldd_error(int status, int errnum, const char *format, ...)
+{
+	assert(program_name != NULL);
+	va_list args;
+	va_start(args, format);
+
+	fflush (stdout);
+	fprintf(stderr, "%s: ", program_name);
+
+	vfprintf(stderr, format, args);
+	va_end(args);
+
+	if (errnum) {
+		fprintf(stderr, ": %s", strerror(errnum));
+	}
+
+	fprintf(stderr, "\n");
+
+	if (status) {
+		exit(status);
+	}
+}

--- a/src/dcfldd_error.h
+++ b/src/dcfldd_error.h
@@ -1,0 +1,25 @@
+/*
+ * dcfldd_error.h -- replacement for non-portable GNU libc's error()
+ * Copyright (C) 2024 David da Silva Polverari
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef DCFLDD_ERROR_H
+#define DCFLDD_ERROR_H
+
+void dcfldd_error(int status, int errnum, const char *format, ...);
+
+#endif /* DCFLDD_ERROR_H */

--- a/src/sha2.h
+++ b/src/sha2.h
@@ -35,6 +35,10 @@
 #ifndef __SHA2_H__
 #define __SHA2_H__
 
+# if HAVE_CONFIG_H
+#  include <config.h>
+# endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,7 +57,7 @@ extern "C" {
  * Define the followingsha2_* types to types of the correct length on
  * the native archtecture.   Most BSD systems and Linux define u_intXX_t
  * types.  Machines with very recent ANSI C headers, can use the
- * uintXX_t definintions from inttypes.h by defining SHA2_USE_INTTYPES_H
+ * uintXX_t definintions from inttypes.h by defining HAVE_INTTYPES_H
  * during compile or in the sha.h header file.
  *
  * Machines that support neither u_intXX_t nor inttypes.h's uintXX_t
@@ -63,7 +67,7 @@ extern "C" {
  * Thank you, Jun-ichiro itojun Hagino, for suggesting using u_intXX_t
  * types and pointing out recent ANSI C support for uintXX_t in inttypes.h.
  */
-#ifdef SHA2_USE_INTTYPES_H
+#ifdef HAVE_INTTYPES_H
 
 #include <inttypes.h>
 
@@ -71,13 +75,13 @@ typedef uint8_t  sha2_byte;	/* Exactly 1 byte */
 typedef uint32_t sha2_word32;	/* Exactly 4 bytes */
 typedef uint64_t sha2_word64;	/* Exactly 8 bytes */
 
-#else /* SHA2_USE_INTTYPES_H */
+#else /* HAVE_INTTYPES_H */
 
 typedef u_int8_t  sha2_byte;	/* Exactly 1 byte */
 typedef u_int32_t sha2_word32;	/* Exactly 4 bytes */
 typedef u_int64_t sha2_word64;	/* Exactly 8 bytes */
 
-#endif /* SHA2_USE_INTTYPES_H */
+#endif /* HAVE_INTTYPES_H */
 
 /*** SHA-256/384/512 Various Length Definitions ***********************/
 #define SHA256_BLOCK_LENGTH		64
@@ -111,13 +115,13 @@ typedef unsigned long long u_int64_t;	/* 8-bytes (64-bits) */
  *
  * If you choose to use <inttypes.h> then please define:
  *
- *   #define SHA2_USE_INTTYPES_H
+ *   #define HAVE_INTTYPES_H
  *
  * Or on the command line during compile:
  *
- *   cc -DSHA2_USE_INTTYPES_H ...
+ *   cc -DHAVE_INTTYPES_H ...
  */
-#ifdef SHA2_USE_INTTYPES_H
+#ifdef HAVE_INTTYPES_H
 
 typedef struct _SHA256_CTX {
 	uint32_t	state[8];
@@ -130,7 +134,7 @@ typedef struct _SHA512_CTX {
 	uint8_t	buffer[SHA512_BLOCK_LENGTH];
 } SHA512_CTX;
 
-#else /* SHA2_USE_INTTYPES_H */
+#else /* HAVE_INTTYPES_H */
 
 typedef struct _SHA256_CTX {
 	u_int32_t	state[8];
@@ -143,14 +147,14 @@ typedef struct _SHA512_CTX {
 	u_int8_t	buffer[SHA512_BLOCK_LENGTH];
 } SHA512_CTX;
 
-#endif /* SHA2_USE_INTTYPES_H */
+#endif /* HAVE_INTTYPES_H */
 
 typedef SHA512_CTX SHA384_CTX;
 
 
 /*** SHA-256/384/512 Function Prototypes ******************************/
 #ifndef NOPROTO
-#ifdef SHA2_USE_INTTYPES_H
+#ifdef HAVE_INTTYPES_H
 
 void SHA256_Init(SHA256_CTX *);
 void SHA256_Update(SHA256_CTX*, const uint8_t*, size_t);
@@ -170,7 +174,7 @@ void SHA512_Final(SHA512_CTX*, uint8_t[SHA512_DIGEST_LENGTH]);
 char* SHA512_End(SHA512_CTX*, char[SHA512_DIGEST_STRING_LENGTH]);
 char* SHA512_Data(const uint8_t*, size_t, char[SHA512_DIGEST_STRING_LENGTH]);
 
-#else /* SHA2_USE_INTTYPES_H */
+#else /* HAVE_INTTYPES_H */
 
 void SHA256_Init(SHA256_CTX *);
 void SHA256_Update(SHA256_CTX*, const u_int8_t*, size_t);
@@ -190,7 +194,7 @@ void SHA512_Final(SHA512_CTX*, u_int8_t[SHA512_DIGEST_LENGTH]);
 char* SHA512_End(SHA512_CTX*, char[SHA512_DIGEST_STRING_LENGTH]);
 char* SHA512_Data(const u_int8_t*, size_t, char[SHA512_DIGEST_STRING_LENGTH]);
 
-#endif /* SHA2_USE_INTTYPES_H */
+#endif /* HAVE_INTTYPES_H */
 
 #else /* NOPROTO */
 

--- a/src/util.c
+++ b/src/util.c
@@ -120,7 +120,8 @@ void skip2(int fdesc, char *file, uintmax_t records, size_t blocksize,
 
 #ifdef __linux__
 
-# include <error.h>
+# include "dcfldd_error.h"
+
 # include <sys/mtio.h>
 
 # define MT_SAME_POSITION(P, Q) \
@@ -144,7 +145,7 @@ static off_t skip_via_lseek(char const *filename, int fdesc, off_t offset,
         && ioctl (fdesc, MTIOCGET, &s2) == 0
         && MT_SAME_POSITION (s1, s2))
     {
-        error (0, 0, _("warning: working around lseek kernel bug for file (%s)\n\
+        dcfldd_error (0, 0, _("warning: working around lseek kernel bug for file (%s)\n\
   of mt_type=0x%0lx -- see <sys/mtio.h> for the list of types"),
                filename, s2.mt_type);
         errno = 0;

--- a/src/xstrtol.c
+++ b/src/xstrtol.c
@@ -252,7 +252,7 @@ __xstrtol (const char *s, char **ptr, int strtol_base,
 #ifdef TESTING_XSTRTO
 
 # include <stdio.h>
-# include "error.h"
+# include "dcfldd_error.h"
 
 char *program_name;
 

--- a/src/xstrtol.h
+++ b/src/xstrtol.h
@@ -38,17 +38,17 @@ _DECLARE_XSTRTOL (xstrtoumax, uintmax_t)
 	  abort ();							\
 									\
 	case LONGINT_INVALID:						\
-	  error ((Exit_code), 0, "invalid %s `%s'",			\
+	  dcfldd_error ((Exit_code), 0, "invalid %s `%s'",			\
 		 (Argument_type_string), (Str));			\
 	  break;							\
 									\
 	case LONGINT_INVALID_SUFFIX_CHAR:				\
-	  error ((Exit_code), 0, "invalid character following %s `%s'",	\
+	  dcfldd_error ((Exit_code), 0, "invalid character following %s `%s'",	\
 		 (Argument_type_string), (Str));			\
 	  break;							\
 									\
 	case LONGINT_OVERFLOW:						\
-	  error ((Exit_code), 0, "%s `%s' too large",			\
+	  dcfldd_error ((Exit_code), 0, "%s `%s' too large",			\
 		 (Argument_type_string), (Str));			\
 	  break;							\
 	}								\


### PR DESCRIPTION
This avoids the dependency on glibc's non-standard `error()` function with our own implementation. This is done to enable usage of other C standard library implementations.