### PR TITLE
`configure.ac`: Migrate off of deprecated macro `AC_HELP_STRING`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_TYPE_OFF_T
 AC_TYPE_SIZE_T
 
 AC_ARG_ENABLE([runtime-endian-check],
-    AC_HELP_STRING([--disable-runtime-endian-check], [disable runtime checks for endianness])
+    AS_HELP_STRING([--disable-runtime-endian-check],[disable runtime checks for endianness])
 )
 
 AC_ARG_WITH([bash-completion],


### PR DESCRIPTION
.. onto `AS_HELP_STRING` of Autoconf >=2.57a. As suggested by autoupdate.

Related Autoconf upstream commit:
https://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commit;h=ed71ef7fc3b8c5598bda5a79a7f7d682a4268cc2